### PR TITLE
Add default manager and staff credentials to settings

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -13,10 +13,10 @@ class Settings(BaseSettings):
     SENTRY_DSN: str | None = None
     FIRST_SUPERUSER_EMAIL: EmailStr
     FIRST_SUPERUSER_PASSWORD: str
-    FIRST_MANAGER_EMAIL: EmailStr
-    FIRST_MANAGER_PASSWORD: str
-    FIRST_STAFF_EMAIL: EmailStr
-    FIRST_STAFF_PASSWORD: str
+    FIRST_MANAGER_EMAIL: EmailStr = "manager@example.com"
+    FIRST_MANAGER_PASSWORD: str = "manager"
+    FIRST_STAFF_EMAIL: EmailStr = "staff@example.com"
+    FIRST_STAFF_PASSWORD: str = "staff"
     CORS_ORIGINS: list[str] = ["http://localhost:3000"]
 
     class Config:


### PR DESCRIPTION
## Summary
- avoid Settings validation error by providing default manager and staff credentials

## Testing
- `poetry run pytest` *(fails: No module named 'email_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68b7c4f2c53c8326b1613355c1831a95