### PR TITLE
chore: ignore e2e tests in jest

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -8,6 +8,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
   preset: 'ts-jest',
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.85.3",


### PR DESCRIPTION
## Summary
- ignore playwright e2e suite in Jest
- add a script for running Playwright tests separately

## Testing
- `npm test` (fails: No QueryClient set, use QueryClientProvider)
- `npm run test:e2e -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68b7cefd95948326be0f41151d26f5c9