### PR TITLE
test: provide react-query context for Shell

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -9,6 +9,9 @@ const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   preset: 'ts-jest',
   testPathIgnorePatterns: ['<rootDir>/e2e/'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/web/src/tests/Shell.test.tsx
+++ b/web/src/tests/Shell.test.tsx
@@ -1,10 +1,26 @@
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Shell from '@/components/layout/Shell';
+
+jest.mock('@/lib/api', () => ({
+  getUsersMe: jest.fn().mockResolvedValue({ id: 1, role: 'user' }),
+}));
 
 describe('Shell', () => {
   it('renders the main heading', () => {
-    render(<Shell><div>Test</div></Shell>);
-    const heading = screen.getByRole('heading', { name: /inventory management/i });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Shell>
+          <div>Test</div>
+        </Shell>
+      </QueryClientProvider>,
+    );
+    const heading = screen.getByRole('heading', {
+      name: /inventory management/i,
+    });
     expect(heading).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- mock `getUsersMe` in Shell test to avoid network calls
- supply a react-query client and provider when rendering `Shell`
- map `@/` alias in Jest config for tests

## Testing
- `npm test --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfcad94083269114280f677ed1cb