### PR TITLE
Accept JSON credentials for login

### DIFF
--- a/api/app/api/endpoints/auth.py
+++ b/api/app/api/endpoints/auth.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.security import OAuth2PasswordRequestForm
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from app import crud
@@ -11,15 +12,23 @@ from app.deps import get_db
 router = APIRouter()
 
 
+class LoginRequest(BaseModel):
+    """Schema for login requests."""
+
+    email: EmailStr
+    password: str
+
+
 @router.post("/login")
 def login_for_access_token(
-    request: Request, response: Response, db: Session = Depends(get_db), form_data: OAuth2PasswordRequestForm = Depends()
+    login_data: LoginRequest,
+    response: Response,
+    db: Session = Depends(get_db),
 ):
-    """
-    OAuth2 compatible token login, get an access token for future requests.
-    """
+    """Token login, get an access token for future requests."""
+
     user = crud.authenticate_user(
-        db, email=form_data.username, password=form_data.password
+        db, email=login_data.email, password=login_data.password
     )
     if not user:
         raise HTTPException(status_code=401, detail="Incorrect email or password")

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -14,7 +14,7 @@ export default function LoginPage() {
     e.preventDefault();
 
     try {
-      await login({ username: email, password });
+      await login({ email, password });
       router.push('/');
     } catch (error) {
       // Handle error

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -29,13 +29,14 @@ async function request(endpoint: string, options: RequestInit = {}, contentType:
 // Auth
 export const getUsersMe = () => request('/users/me');
 export const login = (data: any) => {
-  const body = new URLSearchParams();
-  body.append('username', data.username);
-  body.append('password', data.password);
-  return request('/auth/login', {
-    method: 'POST',
-    body,
-  }, 'application/x-www-form-urlencoded');
+  return request(
+    '/auth/login',
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    },
+    'application/json'
+  );
 };
 
 // Settings


### PR DESCRIPTION
## Summary
- Accept JSON body with email and password for `/auth/login`
- Update frontend login API and form to post JSON credentials

## Testing
- `DATABASE_URL=sqlite:// SECRET_KEY=secret FIRST_SUPERUSER_EMAIL=admin@example.com FIRST_SUPERUSER_PASSWORD=admin PYTHONPATH=. pytest app/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d74b4f348326be5f17904351e566