### PR TITLE
Accept JSON credentials for login

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -14,7 +14,7 @@ export default function LoginPage() {
     e.preventDefault();
 
     try {
-      await login({ username: email, password });
+      await login({ email, password });
       router.push('/');
     } catch (error) {
       // Handle error

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -29,13 +29,14 @@ async function request(endpoint: string, options: RequestInit = {}, contentType:
 // Auth
 export const getUsersMe = () => request('/users/me');
 export const login = (data: any) => {
-  const body = new URLSearchParams();
-  body.append('username', data.username);
-  body.append('password', data.password);
-  return request('/auth/login', {
-    method: 'POST',
-    body,
-  }, 'application/x-www-form-urlencoded');
+  return request(
+    '/auth/login',
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    },
+    'application/json'
+  );
 };
 
 // Settings


### PR DESCRIPTION
## Summary
- Accept JSON or form payloads for `/auth/login`

## Testing
- `DATABASE_URL=sqlite:// SECRET_KEY=secret FIRST_SUPERUSER_EMAIL=admin@example.com FIRST_SUPERUSER_PASSWORD=admin PYTHONPATH=. pytest app/tests`
- `npm test --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_68b7d74b4f348326be5f17904351e566