### PR TITLE
Fix login request payload

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -12,12 +12,17 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    const body = new URLSearchParams({
+      username: email,
+      password,
+    });
+
     const response = await fetch('/api/auth/login', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: JSON.stringify({ email, password }),
+      body: body.toString(),
     });
 
     if (response.ok) {


### PR DESCRIPTION
## Summary
- send login credentials as URL-encoded form fields so FastAPI OAuth2 login succeeds

## Testing
- `npm test` (fails: Playwright test misconfiguration / missing QueryClient)


------
https://chatgpt.com/codex/tasks/task_e_68b7dfcf07ec8326bd1f4c6c0d34e694