### PR TITLE
Use Python 3.10 in API workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: pip install -r api/requirements.txt
       - name: Run linter
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: pip install -r api/requirements.txt
       - name: Run type checker
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: pip install -r api/requirements.txt
       - name: Run tests


### PR DESCRIPTION
## Summary
- run API CI jobs on Python 3.10

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89816b1108326bddc3b3eb59b545a