### PR TITLE
Add default database URL in API example env

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Inventory Management API
 ENVIRONMENT=development
 API_VERSION=0.1.0
-DATABASE_URL=
+DATABASE_URL=sqlite:///./test.db
 SECRET_KEY=mysecretkey
 SENTRY_DSN=
 POSTMARK_SERVER_TOKEN=


### PR DESCRIPTION
## Summary
- provide a default sqlite DATABASE_URL in the API example env

## Testing
- `poetry run ruff check .`
- `poetry run mypy app`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8982ec910832693733f48112a05f4