### PR TITLE
Add PyPI source configuration

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -56,3 +56,4 @@ build-backend = "poetry.core.masonry.api"
 [[tool.poetry.source]]
 name = "apryse"
 url = "https://pypi.apryse.com"
+priority = "supplemental"


### PR DESCRIPTION
## Summary
- configure Poetry to treat Apryse index as supplemental so the default PyPI index remains available

## Testing
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89ba7c644832698c6a4410ae9fa86