### PR TITLE
Handle empty database URL in settings

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -1,11 +1,8 @@
 from logging.config import fileConfig
-from os import getenv
-
-from dotenv import load_dotenv
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import engine_from_config, pool
 
 from alembic import context
+from app.core.config import settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -26,9 +23,8 @@ target_metadata = Base.metadata
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
-load_dotenv(dotenv_path=".env")
 # then pass the database URL to the config
-config.set_main_option("sqlalchemy.url", str(getenv("DATABASE_URL")))
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 
 def run_migrations_offline() -> None:

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -1,11 +1,11 @@
-from pydantic import EmailStr
+from pydantic import EmailStr, field_validator
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     APP_NAME: str = "Inventory Management API"
     ENVIRONMENT: str = "development"
     API_VERSION: str = "0.1.0"
-    DATABASE_URL: str = "sqlite:///./test.db"
+    DATABASE_URL: str | None = None
     SECRET_KEY: str = "changeme"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     FIRST_STAFF_EMAIL: EmailStr = "staff@example.com"
     FIRST_STAFF_PASSWORD: str = "staff"
     CORS_ORIGINS: list[str] = ["http://localhost:3000"]
+
+    @field_validator("DATABASE_URL", mode="before")
+    @classmethod
+    def default_database_url(cls, v: str | None) -> str:
+        return v or "sqlite:///./test.db"
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- default to sqlite database when `DATABASE_URL` env var is missing or empty
- configure Alembic to use `settings.DATABASE_URL` so migrations run without a DB URL

## Testing
- `poetry run ruff check .`
- `poetry run mypy app`
- `poetry run pytest`
- `poetry run python seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8a43201708326bab57bf1991fd241